### PR TITLE
Add TIMEOUT envrionment variable

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,6 +3,7 @@ set -Eeuo pipefail
 
 USERNAME=${USERNAME:-admin}
 PASSWORD=${PASSWORD:-admin}
+TIMEOUT=${TIMEOUT:-15}
 RELAYHOST=${RELAYHOST:-smtp}
 SMTPPORT=${SMTPPORT:-25}
 
@@ -245,9 +246,9 @@ fi
 
 echo "Starting Greenbone Security Assistant..."
 if [ $HTTPS == "true" ]; then
-	su -c "gsad --verbose --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0 --no-redirect --mlisten=127.0.0.1 --mport=9390 --port=9392" gvm
+	su -c "gsad --verbose --gnutls-priorities=SECURE128:-AES-128-CBC:-CAMELLIA-128-CBC:-VERS-SSL3.0:-VERS-TLS1.0 --timeout=$TIMEOUT --no-redirect --mlisten=127.0.0.1 --mport=9390 --port=9392" gvm
 else
-	su -c "gsad --verbose --http-only --no-redirect --mlisten=127.0.0.1 --mport=9390 --port=9392" gvm
+	su -c "gsad --verbose --http-only --timeout=$TIMEOUT --no-redirect --mlisten=127.0.0.1 --mport=9390 --port=9392" gvm
 fi
 
 if [ $SSHD == "true" ]; then


### PR DESCRIPTION
In reference to issue #68 , this adds a TIMEOUT environment variable that will set the web timeout launch option on gsad. Defaults to 15 minutes per original default if not set.