### PR TITLE
add execute permissions to scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,4 +151,6 @@ COPY sshd_config /sshd_config
 
 COPY scripts/* /
 
+RUN chmod +x /*.sh
+
 CMD '/start.sh'


### PR DESCRIPTION
In some cases, the `start.sh` and other scripts cannot be executed and we get `Permission denied` error since the lack of execute permission. So we should add execute permissions to them to ensure they run well.