### PR TITLE
[#124] Disable PostgreSQL's JIT

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -104,6 +104,7 @@ if [ ! -f "/data/firstrun" ]; then
 	
 	echo "listen_addresses = '*'" >> /data/database/postgresql.conf
 	echo "port = 5432" >> /data/database/postgresql.conf
+	echo "jit = off" >> /data/database/postgresql.conf
 	
 	echo "host    all             all              0.0.0.0/0                 md5" >> /data/database/pg_hba.conf
 	echo "host    all             all              ::/0                      md5" >> /data/database/pg_hba.conf


### PR DESCRIPTION
PostgreSQL 12 contains a JIT engine that is enabled by default.
In some cases, the JIT engine can fail spectacularly and cause some queries to become easily over 100x slower.

This is the case for some of the queries used in compiling results in GVM, which, on a moderately powerful server CPU, makes a task supposed to take a moderate 40ms, take about 22000ms.

Disabling the JIT engine goes around this constraint, taking the task back to 40ms

Fixes #124