### PR TITLE
update gvmd/gvm-libs to 20.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ COPY install-pkgs.sh /install-pkgs.sh
 
 RUN bash /install-pkgs.sh
 
-ENV gvm_libs_version="v20.8.0" \
+ENV gvm_libs_version="v20.8.1" \
     openvas_scanner_version="v20.8.0" \
-    gvmd_version="v20.8.0" \
+    gvmd_version="v20.8.1" \
     gsa_version="v20.8.0" \
     gvm_tools_version="2.1.0" \
     openvas_smb="v1.0.5" \


### PR DESCRIPTION
I updated gvmd and gvm-libs to 20.8.1.

close #129 because gvmd 20.8.1 contains the fixes of https://community.greenbone.net/t/skipping-nvt-1-3-6-1-4-1-25623-1-0-150081/8280/12 (https://github.com/greenbone/gvmd/pull/1366)
