### PR TITLE
Added socket file deletion

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -257,13 +257,11 @@ sed -i "s/^relayhost.*$/relayhost = ${RELAYHOST}:${SMTPPORT}/" /etc/postfix/main
 service postfix start
 
 echo "Starting Open Scanner Protocol daemon for OpenVAS..."
-ospd-openvas --log-file /usr/local/var/log/gvm/ospd-openvas.log --unix-socket /var/run/ospd/ospd.sock --log-level INFO
+ospd-openvas --log-file /usr/local/var/log/gvm/ospd-openvas.log --unix-socket /var/run/ospd/ospd.sock --socket-mode 0o666 --log-level INFO
 
 while  [ ! -S /var/run/ospd/ospd.sock ]; do
 	sleep 1
 done
-
-chmod 666 /var/run/ospd/ospd.sock
 
 echo "Creating OSPd socket link from old location..."
 rm -rf /tmp/ospd.sock

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -327,7 +327,7 @@ if [ $SSHD == "true" ]; then
 fi
 
 echo "++++++++++++++++++++++++++++++++++++++++++++++"
-echo "+ Your GVM 20.04 container is now ready to use! +"
+echo "+ Your GVM 20.8.1 container is now ready to use! +"
 echo "++++++++++++++++++++++++++++++++++++++++++++++"
 echo ""
 echo "-----------------------------------------------------------"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -244,6 +244,10 @@ if [ -S /tmp/ospd.sock ]; then
   rm /tmp/ospd.sock
 fi
 
+if [ -S /var/run/ospd/ospd.sock ]; then
+  rm /var/run/ospd/ospd.sock
+fi
+
 if [ ! -d /var/run/ospd ]; then
   mkdir /var/run/ospd
 fi


### PR DESCRIPTION
**Added socket file deletion before starting ospd-openvas.**
When restarting the GVM container, the socket file still remain.
So "sleep 1" won't work and chmod sometimes runs faster than the socket file is recreated by ospd-openvas.
As a result, its permission becomes 700, which is default value of ospd-openvas.

Related Issues, Discussions: #117, #139, and etc...