### PR TITLE
Add control over auto-sync on startup

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,6 +7,7 @@ TIMEOUT=${TIMEOUT:-15}
 RELAYHOST=${RELAYHOST:-smtp}
 SMTPPORT=${SMTPPORT:-25}
 
+AUTO_SYNC=${AUTO_SYNC:-true}
 HTTPS=${HTTPS:-true}
 TZ=${TZ:-UTC}
 SSHD=${SSHD:-false}
@@ -229,8 +230,11 @@ if [ ! -h /usr/local/var/lib/gvm/data-objects ]; then
 	chown gvm:gvm -R /usr/local/var/lib/gvm/data-objects
 fi
 
-# Sync NVTs, CERT data, and SCAP data on container start
-/sync-all.sh
+if [ "$AUTO_SYNC" = true ] || [ ! -f "/firstsync" ]; then
+	# Sync NVTs, CERT data, and SCAP data on container start
+	/sync-all.sh
+	touch /firstsync
+fi
 
 ###########################
 #Remove leftover pid files#


### PR DESCRIPTION
Re-creating the old pull request - fixed and updated with the latest changes.

This would add the simple capability of controlling sync after the first initial startup.

The flag AUTO_SYNC was added with a default value of true, resulting in by default the same functionality we have today.
When AUTO_SYNC is set to false and this is not the first startup of the container, we skip the sync.

This simple change is important for systems without a consistent network connections.