### PR TITLE
Copy 'pre-sync data.tar.xz' to correct gvmd data folder

### DIFF
--- a/scripts/sync-all.sh
+++ b/scripts/sync-all.sh
@@ -4,20 +4,22 @@ if [ ! -f "/data/firstsync" ]; then
 	echo "Downloading data TAR to speed up first sync..."
 	curl -o /tmp/data.tar.xz https://vulndata.securecompliance.solutions/file/VulnData/data.tar.xz # This file is updated at 0:00 UTC every day
 	mkdir /tmp/data
-	
+
 	echo "Extracting data TAR..."
 	tar --extract --file=/tmp/data.tar.xz --directory=/tmp/data
-	
+
+	chown gvm:gvm -R /tmp/data
+
 	mv /tmp/data/nvt-feed/* /usr/local/var/lib/openvas/plugins
-	mv /tmp/data/gvmd-data/* /usr/local/var/lib/gvm/data-objects
+	mv /tmp/data/gvmd-data/* /usr/local/var/lib/gvm/data-objects/gvmd
 	mv /tmp/data/scap-data/* /usr/local/var/lib/gvm/scap-data
 	mv /tmp/data/cert-data/* /usr/local/var/lib/gvm/cert-data
-	
+
 	chown gvm:gvm -R /usr/local/var/lib/openvas/plugins
 	chown gvm:gvm -R /usr/local/var/lib/gvm/data-objects
 	chown gvm:gvm -R /usr/local/var/lib/gvm/scap-data
 	chown gvm:gvm -R /usr/local/var/lib/gvm/cert-data
-	
+
 	rm /tmp/data.tar.xz
 	rm -r /tmp/data
 fi


### PR DESCRIPTION
What does this fix?
- This fix copy the re-sync files that downloaded as data.tar.xz to the correct folder
- with this fix the sync will really only download what is missed and not make a full sync

Fixes #205 
