### PR TITLE
fix(supervisord): gsad binary path correction

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -146,7 +146,7 @@ stopasgroup=true
 killasgroup=true
 
 [program:gsad]
-command=/usr/sbin/gsad -f --verbose --http-only --timeout=%(ENV_TIMEOUT)s --no-redirect --mlisten=127.0.0.1 --mport=9390 --port=9392
+command=/usr/bin/gsad -f --verbose --http-only --timeout=%(ENV_TIMEOUT)s --no-redirect --mlisten=127.0.0.1 --mport=9390 --port=9392
 stdout_logfile=/var/log/supervisor/%(program_name)s.log
 stderr_logfile=/var/log/supervisor/%(program_name)s_err.log
 priority=30


### PR DESCRIPTION
## Summary

Fixes gsad HTTP-only launch failure


### Checklist

Delete any items that are not applicable to this PR.


### Enhancements:
None

### Fixed Bug/Issues solved:
Resolves #232

### Braking Changes:
None
